### PR TITLE
FIX 1.2.1 - `enabled` not set for some menus (reports)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,20 @@
+# ChangeLog
+
+# CHANGELOG FOR MANDARIN MODULE
+
+## Not Released
+
+- 1.2.1 : FIX menus not enabled for sales / purchases / turnover
+  progression reports *2021-03-31* - 1.2.1.
+  
+  In older Dolibarr versions (pre-13.0), the key `enabled` for menu
+  descriptors was optional; when not set, the menu was enabled by
+  default. Now it is mandatory.
+
+## 1.2
+
+- No changelog available
+
+## 1.1
+
+- No changelog available

--- a/core/modules/modmandarin.class.php
+++ b/core/modules/modmandarin.class.php
@@ -40,9 +40,9 @@ class modmandarin extends DolibarrModules
 	 */
 	function __construct($db)
 	{
-        global $langs,$conf;
+		global $langs,$conf;
 
-        $this->db = $db;
+		$this->db = $db;
 
 		// Id for module (must be unique).
 		// Use here a free id (See in Home -> System information -> Dolibarr for list of used modules id).
@@ -58,7 +58,7 @@ class modmandarin extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module mandarin";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.2.0';
+		$this->version = '1.2.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)
@@ -82,7 +82,7 @@ class modmandarin extends DolibarrModules
 		//							'barcode' => 0,                                  	// Set this to 1 if module has its own barcode directory (core/modules/barcode)
 		//							'models' => 0,                                   	// Set this to 1 if module has its own models directory (core/modules/xxx)
 		//							'css' => array('/mandarin/css/mandarin.css.php'),	// Set this to relative path of css file if module has its own css file
-	 	//							'js' => array('/mandarin/js/mandarin.js'),          // Set this to relative path of js file if module must load a js on all pages
+		//							'js' => array('/mandarin/js/mandarin.js'),          // Set this to relative path of js file if module must load a js on all pages
 		//							'hooks' => array('hookcontext1','hookcontext2')  	// Set here all hooks context managed by module
 		//							'dir' => array('output' => 'othermodulename'),      // To force the default directories names
 		//							'workflow' => array('WORKFLOW_MODULE1_YOURACTIONTYPE_MODULE2'=>array('enabled'=>'! empty($conf->module1->enabled) && ! empty($conf->module2->enabled)', 'picto'=>'yourpicto@mandarin')) // Set here all workflow context managed by module
@@ -117,8 +117,8 @@ class modmandarin extends DolibarrModules
 
 		// Array to add new pages in new tabs
 		// Example: $this->tabs = array('objecttype:+tabname1:Title1:mylangfile@mandarin:$user->rights->mandarin->read:/mandarin/mynewtab1.php?id=__ID__',  	// To add a new tab identified by code tabname1
-        //                              'objecttype:+tabname2:Title2:mylangfile@mandarin:$user->rights->othermodule->read:/mandarin/mynewtab2.php?id=__ID__',  	// To add another new tab identified by code tabname2
-        //                              'objecttype:-tabname:NU:conditiontoremove');                                                     						// To remove an existing tab identified by code tabname
+		//                              'objecttype:+tabname2:Title2:mylangfile@mandarin:$user->rights->othermodule->read:/mandarin/mynewtab2.php?id=__ID__',  	// To add another new tab identified by code tabname2
+		//                              'objecttype:-tabname:NU:conditiontoremove');                                                     						// To remove an existing tab identified by code tabname
 		// where objecttype can be
 		// 'categories_x'	  to add a tab in category view (replace 'x' by type of category (0=product, 1=supplier, 2=customer, 3=member)
 		// 'contact'          to add a tab in contact view
@@ -139,36 +139,36 @@ class modmandarin extends DolibarrModules
 		// 'stock'            to add a tab in stock view
 		// 'thirdparty'       to add a tab in third party view
 		// 'user'             to add a tab in user view
-        $this->tabs = array(
+		$this->tabs = array(
 			'project:+mandarin_rapport:'.$langs->trans('Rapport').':mandarin@mandarin:$user->rights->mandarin->graph->project_task:/mandarin/graph_project_task.php?id=__ID__'
 		);
 
-        // Dictionaries
-	    if (! isset($conf->mandarin->enabled))
-        {
-        	$conf->mandarin=new stdClass();
-        	$conf->mandarin->enabled=0;
-        }
+		// Dictionaries
+		if (! isset($conf->mandarin->enabled))
+		{
+			$conf->mandarin=new stdClass();
+			$conf->mandarin->enabled=0;
+		}
 		$this->dictionaries=array();
-        /* Example:
-        if (! isset($conf->mandarin->enabled)) $conf->mandarin->enabled=0;	// This is to avoid warnings
-        $this->dictionaries=array(
-            'langs'=>'mylangfile@mandarin',
-            'tabname'=>array(MAIN_DB_PREFIX."table1",MAIN_DB_PREFIX."table2",MAIN_DB_PREFIX."table3"),		// List of tables we want to see into dictonnary editor
-            'tablib'=>array("Table1","Table2","Table3"),													// Label of tables
-            'tabsql'=>array('SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table1 as f','SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table2 as f','SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table3 as f'),	// Request to select fields
-            'tabsqlsort'=>array("label ASC","label ASC","label ASC"),																					// Sort order
-            'tabfield'=>array("code,label","code,label","code,label"),																					// List of fields (result of select to show dictionary)
-            'tabfieldvalue'=>array("code,label","code,label","code,label"),																				// List of fields (list of fields to edit a record)
-            'tabfieldinsert'=>array("code,label","code,label","code,label"),																			// List of fields (list of fields for insert)
-            'tabrowid'=>array("rowid","rowid","rowid"),																									// Name of columns with primary key (try to always name it 'rowid')
-            'tabcond'=>array($conf->mandarin->enabled,$conf->mandarin->enabled,$conf->mandarin->enabled)												// Condition to show each dictionary
-        );
-        */
+		/* Example:
+		if (! isset($conf->mandarin->enabled)) $conf->mandarin->enabled=0;	// This is to avoid warnings
+		$this->dictionaries=array(
+			'langs'=>'mylangfile@mandarin',
+			'tabname'=>array(MAIN_DB_PREFIX."table1",MAIN_DB_PREFIX."table2",MAIN_DB_PREFIX."table3"),		// List of tables we want to see into dictonnary editor
+			'tablib'=>array("Table1","Table2","Table3"),													// Label of tables
+			'tabsql'=>array('SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table1 as f','SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table2 as f','SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table3 as f'),	// Request to select fields
+			'tabsqlsort'=>array("label ASC","label ASC","label ASC"),																					// Sort order
+			'tabfield'=>array("code,label","code,label","code,label"),																					// List of fields (result of select to show dictionary)
+			'tabfieldvalue'=>array("code,label","code,label","code,label"),																				// List of fields (list of fields to edit a record)
+			'tabfieldinsert'=>array("code,label","code,label","code,label"),																			// List of fields (list of fields for insert)
+			'tabrowid'=>array("rowid","rowid","rowid"),																									// Name of columns with primary key (try to always name it 'rowid')
+			'tabcond'=>array($conf->mandarin->enabled,$conf->mandarin->enabled,$conf->mandarin->enabled)												// Condition to show each dictionary
+		);
+		*/
 
-        // Boxes
+		// Boxes
 		// Add here list of php file(s) stored in core/boxes that contains class to show a box.
-        $this->boxes = array();			// List of boxes
+		$this->boxes = array();			// List of boxes
 		// Example:
 		//$this->boxes=array(array(0=>array('file'=>'myboxa.php','note'=>'','enabledbydefaulton'=>'Home'),1=>array('file'=>'myboxb.php','note'=>''),2=>array('file'=>'myboxc.php','note'=>'')););
 
@@ -262,61 +262,61 @@ class modmandarin extends DolibarrModules
 		$this->rights[$r][5] = 'project_by_user';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
 
-        $this->rights[$r][0] = $this->numero . $r;      // Permission id (must not be already used)
-        $this->rights[$r][1] = 'costPriceTraceGraph';
-        $this->rights[$r][3] = 0;                                       // Permission by default for new user (0/1)
-        $this->rights[$r][4] = 'graph';                         // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $this->rights[$r][5] = 'product_cost_price';                               // In php code, permission will be checked by test if ($user->rights->permkey->$
-        $r++;
+		$this->rights[$r][0] = $this->numero . $r;      // Permission id (must not be already used)
+		$this->rights[$r][1] = 'costPriceTraceGraph';
+		$this->rights[$r][3] = 0;                                       // Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'graph';                         // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = 'product_cost_price';                               // In php code, permission will be checked by test if ($user->rights->permkey->$
+		$r++;
 
-        $this->rights[$r][0] = $this->numero . $r;      // Permission id (must not be already used)
-        $this->rights[$r][1] = 'permCAClientMonth';
-        $this->rights[$r][3] = 0;                                       // Permission by default for new user (0/1)
-        $this->rights[$r][4] = 'graph';                         // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $this->rights[$r][5] = 'ca_client_month';                               // In php code, permission will be checked by test if ($user->rights->permkey->$
-        $r++;
+		$this->rights[$r][0] = $this->numero . $r;      // Permission id (must not be already used)
+		$this->rights[$r][1] = 'permCAClientMonth';
+		$this->rights[$r][3] = 0;                                       // Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'graph';                         // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = 'ca_client_month';                               // In php code, permission will be checked by test if ($user->rights->permkey->$
+		$r++;
 
-        $this->rights[$r][0] = $this->numero . $r;      // Permission id (must not be already used)
-        $this->rights[$r][1] = 'RapportMoyenneProduitsVendusCommandesEnvoyes';
-        $this->rights[$r][3] = 0;                                       // Permission by default for new user (0/1)
-        $this->rights[$r][4] = 'graph';                         // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $this->rights[$r][5] = 'products_average';                               // In php code, permission will be checked by test if ($user->rights->permkey->$
-        $r++;
+		$this->rights[$r][0] = $this->numero . $r;      // Permission id (must not be already used)
+		$this->rights[$r][1] = 'RapportMoyenneProduitsVendusCommandesEnvoyes';
+		$this->rights[$r][3] = 0;                                       // Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'graph';                         // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = 'products_average';                               // In php code, permission will be checked by test if ($user->rights->permkey->$
+		$r++;
 
-        $this->rights[$r][0] = $this->numero . $r;      // Permission id (must not be already used)
-        $this->rights[$r][1] = 'RapportTempsMoyenReceptionProduits';
-        $this->rights[$r][3] = 0;                                       // Permission by default for new user (0/1)
-        $this->rights[$r][4] = 'graph';                         // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $this->rights[$r][5] = 'products_receipt_average';                               // In php code, permission will be checked by test if ($user->rights->permkey->$
-        $r++;
+		$this->rights[$r][0] = $this->numero . $r;      // Permission id (must not be already used)
+		$this->rights[$r][1] = 'RapportTempsMoyenReceptionProduits';
+		$this->rights[$r][3] = 0;                                       // Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'graph';                         // In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = 'products_receipt_average';                               // In php code, permission will be checked by test if ($user->rights->permkey->$
+		$r++;
 
-        $this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
-        $this->rights[$r][1] = $langs->transnoentitiesnoconv('permGraphDiffByCommercial');	// Permission label
-        $this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
-        $this->rights[$r][4] = 'list';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $this->rights[$r][5] = 'diff_by_commercial';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $r++;
+		$this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
+		$this->rights[$r][1] = $langs->transnoentitiesnoconv('permGraphDiffByCommercial');	// Permission label
+		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'list';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = 'diff_by_commercial';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$r++;
 
-        $this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
-        $this->rights[$r][1] = $langs->transnoentitiesnoconv('permReportRepartitionBySupplier');	// Permission label
-        $this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
-        $this->rights[$r][4] = 'list';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $this->rights[$r][5] = 'repartition_by_supplier';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $r++;
+		$this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
+		$this->rights[$r][1] = $langs->transnoentitiesnoconv('permReportRepartitionBySupplier');	// Permission label
+		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'list';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = 'repartition_by_supplier';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$r++;
 
-        $this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
-        $this->rights[$r][1] = $langs->transnoentitiesnoconv('permGraphPropalCommercial');	// Permission label
-        $this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
-        $this->rights[$r][4] = 'graph';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $this->rights[$r][5] = 'propal_commercial';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $r++;
+		$this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
+		$this->rights[$r][1] = $langs->transnoentitiesnoconv('permGraphPropalCommercial');	// Permission label
+		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'graph';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = 'propal_commercial';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$r++;
 
-        $this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
-        $this->rights[$r][1] = $langs->transnoentitiesnoconv('permGraphPropalAllCommercial');	// Permission label
-        $this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
-        $this->rights[$r][4] = 'graph';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $this->rights[$r][5] = 'propal_alldata';	// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
-        $r++;
+		$this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
+		$this->rights[$r][1] = $langs->transnoentitiesnoconv('permGraphPropalAllCommercial');	// Permission label
+		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
+		$this->rights[$r][4] = 'graph';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$this->rights[$r][5] = 'propal_alldata';	// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
+		$r++;
 
 		// Main menu entries
 		$this->menu = array();			// List of menus to add
@@ -644,32 +644,32 @@ class modmandarin extends DolibarrModules
 		$r++;
 
 		$this->menu[$r]=array('fk_menu'=>'fk_mainmenu=commercial,fk_leftmenu=propals',			                // Put 0 if this is a top menu
-		    'type'=>'left',			                // This is a Top menu entry
-		    'titre'=>$langs->transnoentitiesnoconv('linkMenuPropalesByCommercial'),
-		    'mainmenu'=>'',
-		    'leftmenu'=>'',
-		    'url'=>'/mandarin/graph_propales_by_commercial.php',
-		    'langs'=>'mandarin@mandarin',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
-		    'position'=>401,
-		    'enabled'=>'$conf->mandarin->enabled',	// Define condition to show or hide menu entry. Use '$conf->mandarin->enabled' if entry must be visible if module is enabled.
-		    'perms'=>'$user->rights->mandarin->graph->propal_commercial',			                // Use 'perms'=>'$user->rights->mandarin->level1->level2' if you want your menu with a permission rules
-		    'target'=>'',
-		    'user'=>2				                // 0=Menu for internal users, 1=external users, 2=both
+			'type'=>'left',			                // This is a Top menu entry
+			'titre'=>$langs->transnoentitiesnoconv('linkMenuPropalesByCommercial'),
+			'mainmenu'=>'',
+			'leftmenu'=>'',
+			'url'=>'/mandarin/graph_propales_by_commercial.php',
+			'langs'=>'mandarin@mandarin',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+			'position'=>401,
+			'enabled'=>'$conf->mandarin->enabled',	// Define condition to show or hide menu entry. Use '$conf->mandarin->enabled' if entry must be visible if module is enabled.
+			'perms'=>'$user->rights->mandarin->graph->propal_commercial',			                // Use 'perms'=>'$user->rights->mandarin->level1->level2' if you want your menu with a permission rules
+			'target'=>'',
+			'user'=>2				                // 0=Menu for internal users, 1=external users, 2=both
 		);
 		$r++;
 
 		$this->menu[$r]=array('fk_menu'=>'fk_mainmenu=commercial,fk_leftmenu=propals',			                // Put 0 if this is a top menu
-		    'type'=>'left',			                // This is a Top menu entry
-		    'titre'=>$langs->transnoentitiesnoconv('linkMenuCAPropalesByCommercial'),
-		    'mainmenu'=>'',
-		    'leftmenu'=>'',
-		    'url'=>'/mandarin/graph_propales_by_commercial.php?ca=true',
-		    'langs'=>'mandarin@mandarin',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
-		    'position'=>401,
-		    'enabled'=>'$conf->mandarin->enabled',	// Define condition to show or hide menu entry. Use '$conf->mandarin->enabled' if entry must be visible if module is enabled.
-		    'perms'=>'$user->rights->mandarin->graph->propal_commercial',			                // Use 'perms'=>'$user->rights->mandarin->level1->level2' if you want your menu with a permission rules
-		    'target'=>'',
-		    'user'=>2				                // 0=Menu for internal users, 1=external users, 2=both
+			'type'=>'left',			                // This is a Top menu entry
+			'titre'=>$langs->transnoentitiesnoconv('linkMenuCAPropalesByCommercial'),
+			'mainmenu'=>'',
+			'leftmenu'=>'',
+			'url'=>'/mandarin/graph_propales_by_commercial.php?ca=true',
+			'langs'=>'mandarin@mandarin',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+			'position'=>401,
+			'enabled'=>'$conf->mandarin->enabled',	// Define condition to show or hide menu entry. Use '$conf->mandarin->enabled' if entry must be visible if module is enabled.
+			'perms'=>'$user->rights->mandarin->graph->propal_commercial',			                // Use 'perms'=>'$user->rights->mandarin->level1->level2' if you want your menu with a permission rules
+			'target'=>'',
+			'user'=>2				                // 0=Menu for internal users, 1=external users, 2=both
 		);
 		$r++;
 
@@ -688,47 +688,50 @@ class modmandarin extends DolibarrModules
 		);
 		$r++;
 
-        $this->menu[$r]=array(
-            'fk_menu'=>'fk_mainmenu=tools',
-            'type'=>'left',
-            'titre'=>$langs->transnoentitiesnoconv('Reports'),
-            'mainmenu'=>'tools',
-            'leftmenu'=>'rapports',
-            'url'=>'/core/tools.php',
-            'position'=>100,
-            'perms'=>'$user->rights->facture->lire',
-            'target'=>'',
-            'user'=>2
-        );
-        $r++;
+		$this->menu[$r]=array(
+			'fk_menu'=>'fk_mainmenu=tools',
+			'type'=>'left',
+			'titre'=>$langs->transnoentitiesnoconv('Reports'),
+			'mainmenu'=>'tools',
+			'leftmenu'=>'rapports',
+			'url'=>'/core/tools.php',
+			'enabled'=>'$conf->mandarin->enabled',
+			'position'=>100,
+			'perms'=>'$user->rights->facture->lire',
+			'target'=>'',
+			'user'=>2
+		);
+		$r++;
 
-        $this->menu[$r]=array(
-            'fk_menu'=>'fk_mainmenu=tools,fk_leftmenu=rapports',
-            'type'=>'left',
-            'titre'=>$langs->transnoentitiesnoconv('linkMenuReportVentesArticles'),
-            'mainmenu'=>'tools',
-            'leftmenu'=>'rapports_vente_prod',
-            'url'=>'/mandarin/evo_ventes_articles.php',
-            'position'=>100,
-            'perms'=>'$user->rights->facture->lire',
-            'target'=>'',
-            'user'=>2
-        );
-        $r++;
+		$this->menu[$r]=array(
+			'fk_menu'=>'fk_mainmenu=tools,fk_leftmenu=rapports',
+			'type'=>'left',
+			'titre'=>$langs->transnoentitiesnoconv('linkMenuReportVentesArticles'),
+			'mainmenu'=>'tools',
+			'leftmenu'=>'rapports_vente_prod',
+			'url'=>'/mandarin/evo_ventes_articles.php',
+			'enabled'=>'$conf->mandarin->enabled',
+			'position'=>100,
+			'perms'=>'$user->rights->facture->lire',
+			'target'=>'',
+			'user'=>2
+		);
+		$r++;
 
-        $this->menu[$r]=array(
-            'fk_menu'=>'fk_mainmenu=tools,fk_leftmenu=rapports',
-            'type'=>'left',
-            'titre'=>$langs->transnoentitiesnoconv('linkMenuReportCAArticles'),
-            'mainmenu'=>'tools',
-            'leftmenu'=>'rapports_ca_prod',
-            'url'=>'/mandarin/evo_ventes_articles.php?mode=CA',
-            'position'=>100,
-            'perms'=>'$user->rights->facture->lire',
-            'target'=>'',
-            'user'=>2
-        );
-        $r++;
+		$this->menu[$r]=array(
+			'fk_menu'=>'fk_mainmenu=tools,fk_leftmenu=rapports',
+			'type'=>'left',
+			'titre'=>$langs->transnoentitiesnoconv('linkMenuReportCAArticles'),
+			'mainmenu'=>'tools',
+			'leftmenu'=>'rapports_ca_prod',
+			'url'=>'/mandarin/evo_ventes_articles.php?mode=CA',
+			'enabled'=>'$conf->mandarin->enabled',
+			'position'=>100,
+			'perms'=>'$user->rights->facture->lire',
+			'target'=>'',
+			'user'=>2
+		);
+		$r++;
 
 		$this->menu[$r]=array(
 			'fk_menu'=>'fk_mainmenu=tools,fk_leftmenu=rapports',
@@ -737,6 +740,7 @@ class modmandarin extends DolibarrModules
 			'mainmenu'=>'tools',
 			'leftmenu'=>'rapports_achats_prod',
 			'url'=>'/mandarin/evo_achats_articles.php',
+			'enabled'=>'$conf->mandarin->enabled',
 			'position'=>100,
 			'perms'=>'$user->rights->facture->lire',
 			'target'=>'',
@@ -752,6 +756,7 @@ class modmandarin extends DolibarrModules
 			'mainmenu'=>'tools',
 			'leftmenu'=>'rapports_achats_ca_prod',
 			'url'=>'/mandarin/evo_achats_articles.php?mode=CA',
+			'enabled'=>'$conf->mandarin->enabled',
 			'position'=>100,
 			'perms'=>'$user->rights->facture->lire',
 			'target'=>'',
@@ -766,6 +771,7 @@ class modmandarin extends DolibarrModules
 			'mainmenu'=>'tools',
 			'leftmenu'=>'rapports_achats_fourn',
 			'url'=>'/mandarin/evo_achats_fournisseurs.php',
+			'enabled'=>'$conf->mandarin->enabled',
 			'position'=>100,
 			'perms'=>'$user->rights->facture->lire',
 			'target'=>'',
@@ -781,6 +787,7 @@ class modmandarin extends DolibarrModules
 			'mainmenu'=>'tools',
 			'leftmenu'=>'rapports_achats_ca_fourn',
 			'url'=>'/mandarin/evo_achats_fournisseurs.php?mode=CA',
+			'enabled'=>'$conf->mandarin->enabled',
 			'position'=>100,
 			'perms'=>'$user->rights->facture->lire',
 			'target'=>'',
@@ -827,7 +834,7 @@ class modmandarin extends DolibarrModules
 		// Example:
 		// $this->export_code[$r]=$this->rights_class.'_'.$r;
 		// $this->export_label[$r]='CustomersInvoicesAndInvoiceLines';	// Translation key (used only if key ExportDataset_xxx_z not found)
-        // $this->export_enabled[$r]='1';                               // Condition to show export in list (ie: '$user->id==3'). Set to 1 to always show when module is enabled.
+		// $this->export_enabled[$r]='1';                               // Condition to show export in list (ie: '$user->id==3'). Set to 1 to always show when module is enabled.
 		// $this->export_permission[$r]=array(array("facture","facture","export"));
 		// $this->export_fields_array[$r]=array('s.rowid'=>"IdCompany",'s.nom'=>'CompanyName','s.address'=>'Address','s.zip'=>'Zip','s.town'=>'Town','s.fk_pays'=>'Country','s.phone'=>'Phone','s.siren'=>'ProfId1','s.siret'=>'ProfId2','s.ape'=>'ProfId3','s.idprof4'=>'ProfId4','s.code_compta'=>'CustomerAccountancyCode','s.code_compta_fournisseur'=>'SupplierAccountancyCode','f.rowid'=>"InvoiceId",'f.facnumber'=>"InvoiceRef",'f.datec'=>"InvoiceDateCreation",'f.datef'=>"DateInvoice",'f.total'=>"TotalHT",'f.total_ttc'=>"TotalTTC",'f.tva'=>"TotalVAT",'f.paye'=>"InvoicePaid",'f.fk_statut'=>'InvoiceStatus','f.note'=>"InvoiceNote",'fd.rowid'=>'LineId','fd.description'=>"LineDescription",'fd.price'=>"LineUnitPrice",'fd.tva_tx'=>"LineVATRate",'fd.qty'=>"LineQty",'fd.total_ht'=>"LineTotalHT",'fd.total_tva'=>"LineTotalTVA",'fd.total_ttc'=>"LineTotalTTC",'fd.date_start'=>"DateStart",'fd.date_end'=>"DateEnd",'fd.fk_product'=>'ProductId','p.ref'=>'ProductRef');
 		// $this->export_entities_array[$r]=array('s.rowid'=>"company",'s.nom'=>'company','s.address'=>'company','s.zip'=>'company','s.town'=>'company','s.fk_pays'=>'company','s.phone'=>'company','s.siren'=>'company','s.siret'=>'company','s.ape'=>'company','s.idprof4'=>'company','s.code_compta'=>'company','s.code_compta_fournisseur'=>'company','f.rowid'=>"invoice",'f.facnumber'=>"invoice",'f.datec'=>"invoice",'f.datef'=>"invoice",'f.total'=>"invoice",'f.total_ttc'=>"invoice",'f.tva'=>"invoice",'f.paye'=>"invoice",'f.fk_statut'=>'invoice','f.note'=>"invoice",'fd.rowid'=>'invoice_line','fd.description'=>"invoice_line",'fd.price'=>"invoice_line",'fd.total_ht'=>"invoice_line",'fd.total_tva'=>"invoice_line",'fd.total_ttc'=>"invoice_line",'fd.tva_tx'=>"invoice_line",'fd.qty'=>"invoice_line",'fd.date_start'=>"invoice_line",'fd.date_end'=>"invoice_line",'fd.fk_product'=>'product','p.ref'=>'product');
@@ -840,10 +847,10 @@ class modmandarin extends DolibarrModules
 
 		 $this->export_code[$r]=$this->rights_class.'_'.$r;
 		 $this->export_label[$r]='CustomerOrderAndBills';	// Translation key (used only if key ExportDataset_xxx_z not found)
-         $this->export_enabled[$r]='1';                               // Condition to show export in list (ie: '$user->id==3'). Set to 1 to always show when module is enabled.
+		 $this->export_enabled[$r]='1';                               // Condition to show export in list (ie: '$user->id==3'). Set to 1 to always show when module is enabled.
 		 $this->export_permission[$r]=array(array("facture","facture","export"));
 		 $this->export_fields_array[$r]=array('s.rowid'=>"IdCompany",'s.nom'=>'CompanyName','s.address'=>'Address','s.zip'=>'Zip','s.town'=>'Town','f.rowid'=>"InvoiceId",'f.facnumber'=>"InvoiceRef",'f.datec'=>"InvoiceDateCreation",'f.datef'=>"DateInvoice",'f.total'=>"TotalHT",'f.total_ttc'=>"TotalTTC",'f.tva'=>"TotalVAT",'f.paye'=>"InvoicePaid",'f.fk_statut'=>'InvoiceStatus','c.rowid'=>"OrderId",'c.ref'=>"OrderRef",'c.date_creation'=>"OrderDateCreation",'c.date_commande'=>"DateOrder",'c.total_ht'=>"TotalHT",'c.total_ttc'=>"TotalTTC",'c.tva'=>"TotalVAT",'c.fk_statut'=>"OrderStatus");
-         $this->export_fields_array[$r]+=array('u.login'=>'SaleRepresentativeLogin','u.firstname'=>'SaleRepresentativeFirstname', 'u.lastname'=>'SaleRepresentativeLastname');
+		 $this->export_fields_array[$r]+=array('u.login'=>'SaleRepresentativeLogin','u.firstname'=>'SaleRepresentativeFirstname', 'u.lastname'=>'SaleRepresentativeLastname');
 		 $this->export_entities_array[$r]=array('s.rowid'=>"company",'s.nom'=>'company','s.address'=>'company','s.zip'=>'company','s.town'=>'company','f.rowid'=>"invoice",'f.facnumber'=>"invoice",'f.datec'=>"invoice",'f.datef'=>"invoice",'f.total'=>"invoice",'f.total_ttc'=>"invoice",'f.tva'=>"invoice",'f.paye'=>"invoice",'f.fk_statut'=>'invoice','c.rowid'=>"order",'c.ref'=>"order",'c.date_creation'=>"order",'c.date_commande'=>"order",'c.total_ht'=>"order",'c.total_ttc'=>"order",'c.tva'=>"order",'c.fk_statut'=>"order",'u.login'=>'user','u.firstname'=>'user','u.lastname'=>'user');
 		 $this->export_TypeFields_array[$r]=array('s.rowid'=>"Numeric", 's.nom'=>"Text",'s.address'=>'Text','s.zip'=>'Text','s.town'=>'Text','f.rowid'=>"Numeric",'f.facnumber'=>"Text",'f.datec'=>"Date",'f.datef'=>"Date",'f.total'=>"Numeric",'f.total_ttc'=>"Numeric",'f.tva'=>"Numeric",'f.paye'=>"Boolean",'f.fk_statut'=>'Numeric','c.rowid'=>"Numeric",'c.ref'=>"Text",'c.date_creation'=>"Date",'c.date_commande'=>"Date",'c.total_ht'=>"Numeric",'c.total_ttc'=>"Numeric",'c.tva'=>"Numeric",'c.fk_statut'=>"Numeric",'u.login'=>'Text','u.firstname'=>'Text','u.lastname'=>'Text');
 
@@ -866,7 +873,7 @@ class modmandarin extends DolibarrModules
 	 *		The init function add constants, boxes, permissions and menus (defined in constructor) into Dolibarr database.
 	 *		It also creates data directories
 	 *
-     *      @param      string	$options    Options when enabling module ('', 'noboxes')
+	 *      @param      string	$options    Options when enabling module ('', 'noboxes')
 	 *      @return     int             	1 if OK, 0 if KO
 	 */
 	function init($options='')
@@ -881,7 +888,7 @@ class modmandarin extends DolibarrModules
 		$result=$this->_load_tables('/mandarin/sql/');
 
 		dol_include_once('/core/class/extrafields.class.php');
-        $extrafields=new ExtraFields($this->db);
+		$extrafields=new ExtraFields($this->db);
 		$res = $extrafields->addExtraField('contrat', 'Contrat', 'varchar', 0, 150, 'user');
 
 		$extrafields=new ExtraFields($this->db);
@@ -901,7 +908,7 @@ class modmandarin extends DolibarrModules
 	 *      Remove from database constants, boxes and permissions from Dolibarr database.
 	 *		Data directories are not deleted
 	 *
-     *      @param      string	$options    Options when enabling module ('', 'noboxes')
+	 *      @param      string	$options    Options when enabling module ('', 'noboxes')
 	 *      @return     int             	1 if OK, 0 if KO
 	 */
 	function remove($options='')


### PR DESCRIPTION
# FIX 1.2
Les menus des rapports d’évolution du CA, des ventes, des achats, etc. ne sont plus visibles en v13 car la clé `enabled` n’est pas définie dans le descripteur de module.