### PR TITLE
FIX: on evo_achats_articles.php, supplier filter <select> shows all ⅓ parties

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## Not Released
 
+- 1.2.2 : FIX supplier filter on the purchase progression report
+  is not filtered on suppliers *2021-04-06* - 1.2.2. 
 - 1.2.1 : FIX menus not enabled for sales / purchases / turnover
   progression reports *2021-03-31* - 1.2.1.
   

--- a/core/modules/modmandarin.class.php
+++ b/core/modules/modmandarin.class.php
@@ -58,7 +58,7 @@ class modmandarin extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module mandarin";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.2.1';
+		$this->version = '1.2.2';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/evo_achats_articles.php
+++ b/evo_achats_articles.php
@@ -197,7 +197,7 @@ if (! empty($conf->categorie->enabled))
 }
 
 $moreforfilter.='<tr><td>'.$langs->trans('Supplier') . ' : </td>';
-$moreforfilter.='<td colspan="2">'.$form->select_company($fk_soc, 'fk_soc', '', 1).'</td></tr>';
+$moreforfilter.='<td colspan="2">'.$form->select_company($fk_soc, 'fk_soc', 's.fournisseur = 1', 1).'</td></tr>';
 
 $moreforfilter.='<tr><td>'.$langs->trans('Product') . ' : </td>';
 $moreforfilter.='<td colspan="2"><input type="text" name="product_ref" value="'.$product_ref.'" placeholder="'.$langs->trans('Ref') . '" /> <input type="text" name="product_label" value="'.$product_label.'"  placeholder="'.$langs->trans('Label') . '"  /></td></tr>';


### PR DESCRIPTION
# FIX: supplier filter on report
The `<select>` for this filter shows all third parties; it should only show suppliers.
